### PR TITLE
fix: future completing before receiving result

### DIFF
--- a/lib/desktop_webview_auth.dart
+++ b/lib/desktop_webview_auth.dart
@@ -117,7 +117,7 @@ class DesktopWebviewAuth {
       _signInResultCompleter.complete(null);
     } else {
       try {
-        final authResult = await _args.authorizeFromCallback(callbackUrl);
+        final authResult = _args.authorizeFromCallback(callbackUrl);
         _signInResultCompleter.complete(authResult);
       } catch (e) {
         _signInResultCompleter.complete(null);


### PR DESCRIPTION
With Twitter sign in, the future returns before completing the whole auth flow, this PR fixes the issue.