### PR TITLE
fix build error on iOS 16

### DIFF
--- a/ios/Classes/SwiftDesktopWebviewAuthPlugin.swift
+++ b/ios/Classes/SwiftDesktopWebviewAuthPlugin.swift
@@ -9,6 +9,6 @@ public class SwiftDesktopWebviewAuthPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    result(FlutterErrorNotImplemented)
+    result(nil)
   }
 }


### PR DESCRIPTION
FlutterErrorNotImplemented is not existing on iOS 16 and Xcode 14