### PR TITLE
fix: Deprecated package tag in AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.desktop_webview_auth">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Fix the problem that occurs in newer gradle versions:

"Incorrect package="com.example.desktop_webview_auth" found in source AndroidManifest.xml: Pub\Cache\hosted\pub.dev\desktop_webview_auth-0.0.13\android\src\main\AndroidManifest.xml. Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported. Recommendation: remove package="com.example.desktop_webview_auth" from the source AndroidManifest.xml: Pub\Cache\hosted\pub.dev\desktop_webview_auth-0.0.13\android\src\main\AndroidManifest.xml. "