### PR TITLE
Fixes issue with Google Sign in exiting early

### DIFF
--- a/lib/google.dart
+++ b/lib/google.dart
@@ -1,4 +1,5 @@
 import 'src/provider_args.dart';
+import 'src/util.dart';
 
 const _defaultSignInScope = 'https://www.googleapis.com/auth/plus.login';
 
@@ -15,7 +16,7 @@ class GoogleSignInArgs extends ProviderArgs {
   final host = 'accounts.google.com';
 
   @override
-  final path = '/o/oauth2/auth';
+  final path = '/o/oauth2/v2/auth';
 
   GoogleSignInArgs({
     required this.clientId,
@@ -33,6 +34,7 @@ class GoogleSignInArgs extends ProviderArgs {
       'immediate': immediate.toString(),
       'response_type': responseType,
       'redirect_uri': redirectUri,
+      'nonce': generateNonce()
     };
   }
 }

--- a/macos/Classes/DesktopWebviewAuthPlugin.swift
+++ b/macos/Classes/DesktopWebviewAuthPlugin.swift
@@ -45,6 +45,12 @@ public class WebviewController: NSViewController, WKNavigationDelegate {
     
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
+        if navigationAction.navigationType == .formSubmitted {
+            // Call the decisionHandler to allow the navigation to continue
+            decisionHandler(.allow)
+            return
+        }
+
         guard let url = navigationAction.request.url else {
             decisionHandler(.allow);
             return

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: desktop_webview_auth
 description: This package enables Firebase OAuth on desktop via webview
-version: 0.0.13
+version: 0.0.14
 homepage: https://github.com/invertase/flutter_desktop_webview_auth
 
 environment:


### PR DESCRIPTION
This fixes the issue that people are having where Google Sign in exits early, initially raised here: https://github.com/invertase/flutter_desktop_webview_auth/issues/50

`remcova` (https://github.com/remcova) fixed the issue on their local repository, so I've taken a number of their changes and raised a PR here.