### PR TITLE
Add support for webkit2gtk-4.1

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -18,7 +18,11 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
-pkg_check_modules(WEBKIT IMPORTED_TARGET REQUIRED webkit2gtk-4.0)
+pkg_check_modules(WEBKIT IMPORTED_TARGET webkit2gtk-4.1)
+if(NOT WEBKIT_FOUND)
+  pkg_check_modules(WEBKIT IMPORTED_TARGET webkit2gtk-4.0)
+endif()
+
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::WEBKIT)
 
 # List of absolute paths to libraries that should be bundled with the plugin


### PR DESCRIPTION
Ubuntu 24.04 and other newer distros come with a newer version of webkit2gtk - version 4.1. 