### PR TITLE
Fix callback detection in Linux webview

### DIFF
--- a/linux/desktop_webview_auth_plugin.cc
+++ b/linux/desktop_webview_auth_plugin.cc
@@ -48,7 +48,7 @@ static void changed(WebKitWebView *view, WebKitLoadEvent event, gpointer user_da
 
   if (strcmp(plugin->method_name, "signIn") == 0)
   {
-    matching = strstr(uri, redirectUrl) != NULL;
+    matching = strncmp(uri, redirectUrl, strlen(redirectUrl)) == 0;
   }
   else if (strcmp(plugin->method_name, "recaptchaVerification") == 0)
   {


### PR DESCRIPTION
In google oauth, the uri gets passed around via a query parameter which causes the browser window to get closed too early.

`
https://accounts.google.com/CheckCookie?continue=https://accounts.google.com/signin/oauth/consent?...&redirect_uri=...
`

This PR ensures the redirect URL is matched only at the beginning of the current URI.

The change brings it on par with the windows version:
`matching = url.rfind(redirectUrl_, 0) == 0;`